### PR TITLE
Fix dropdown-item width

### DIFF
--- a/_sass/components/_main-menu.scss
+++ b/_sass/components/_main-menu.scss
@@ -24,6 +24,7 @@
   font-size: 14px;
   font-weight: 800;
   padding: 10px 20px;
+  width: auto;
 
   &:hover {
     background-color: inherit;


### PR DESCRIPTION
Default width is set to 100% with Bootstrap. That overflows the dropdown menu. Overriding it with width=auto seems to fix the problem.