### PR TITLE
Fix #14 openmetrics.io link in metrics-over-logs.md

### DIFF
--- a/_operations/metrics-over-logs.md
+++ b/_operations/metrics-over-logs.md
@@ -25,7 +25,7 @@ The purpose of each type of data, logs and metrics, must first be well establish
 - Data sent to logs should be minimized as much as possible.
 - Relevant global metrics must be defined.
 - For each service, the owner must define metrics which are relevant and make them available to the monitoring system.
-- Metrics should comply with the Open Metrics (<https://openmetrics.io/)> standard.
+- Metrics should comply with the Open Metrics (<https://openmetrics.io/>) standard.
 
 ## Consequently
 


### PR DESCRIPTION
Fix the broken link by moving it's closing > symbol to before the ), which is currently being included in the link and breaking it.

Issue #14 